### PR TITLE
Fix FESC spectra loading

### DIFF
--- a/syotools/spectra/utils.py
+++ b/syotools/spectra/utils.py
@@ -76,7 +76,7 @@ def load_fesc(spec):
         path = path / f
     abspath = str(path.resolve())
     tab = asc.read(abspath)
-    sp = pys.ArraySpectrum(wave=tab['lam'], flux=tab['lh1=17.5'], 
+    sp = pys.ArraySpectrum(wave=tab['lam'].value, flux=tab['lh1=17.5'].value, 
                            waveunits='Angstrom', fluxunits='flam')
     sp = sp.renorm(30., 'abmag', pys.ObsBandpass(band))
     sp.convert('abmag')


### PR DESCRIPTION
This small change fixes the load_fesc function, and the spectra that they load for HWO-Tools repo's camera_etc and uvspec_etc.